### PR TITLE
Switch to "dev" branch of tes3 library.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
         run: cargo build --release
 
       - name: compress
-        run: tar -acf ${{ matrix.archive }} -C ./target/release/ ${{ matrix.binary }}
+        run: 7z a -tzip ${{ matrix.archive }} ./target/release/${{ matrix.binary }}
 
       - name: upload
         uses: softprops/action-gh-release@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.vscode/
 target/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ dependencies = [
 [[package]]
 name = "bytes_io"
 version = "0.0.1"
-source = "git+https://github.com/Greatness7/tes3?branch=dev#9d670bda8f0e2c815f5891ac5545b3df7fb5947c"
+source = "git+https://github.com/Greatness7/tes3?branch=dev#9ceebf5721f658ac0f48b9c5e93c36b4bb3de67a"
 dependencies = [
  "bstr",
  "bytemuck",
@@ -145,7 +145,7 @@ dependencies = [
 [[package]]
 name = "bytes_io_macros"
 version = "0.0.1"
-source = "git+https://github.com/Greatness7/tes3?branch=dev#9d670bda8f0e2c815f5891ac5545b3df7fb5947c"
+source = "git+https://github.com/Greatness7/tes3?branch=dev#9ceebf5721f658ac0f48b9c5e93c36b4bb3de67a"
 dependencies = [
  "quote",
  "syn 2.0.66",
@@ -264,7 +264,7 @@ dependencies = [
 [[package]]
 name = "esp"
 version = "0.0.1"
-source = "git+https://github.com/Greatness7/tes3?branch=dev#9d670bda8f0e2c815f5891ac5545b3df7fb5947c"
+source = "git+https://github.com/Greatness7/tes3?branch=dev#9ceebf5721f658ac0f48b9c5e93c36b4bb3de67a"
 dependencies = [
  "bitflags",
  "bstr",
@@ -282,7 +282,7 @@ dependencies = [
 [[package]]
 name = "esp_macros"
 version = "0.0.1"
-source = "git+https://github.com/Greatness7/tes3?branch=dev#9d670bda8f0e2c815f5891ac5545b3df7fb5947c"
+source = "git+https://github.com/Greatness7/tes3?branch=dev#9ceebf5721f658ac0f48b9c5e93c36b4bb3de67a"
 dependencies = [
  "quote",
  "syn 2.0.66",
@@ -515,7 +515,7 @@ dependencies = [
 [[package]]
 name = "tes3"
 version = "0.0.1"
-source = "git+https://github.com/Greatness7/tes3?branch=dev#9d670bda8f0e2c815f5891ac5545b3df7fb5947c"
+source = "git+https://github.com/Greatness7/tes3?branch=dev#9ceebf5721f658ac0f48b9c5e93c36b4bb3de67a"
 dependencies = [
  "esp",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "2.0.1"
 dependencies = [
  "clap",
  "levenshtein",
+ "mimalloc",
  "rayon",
  "regex",
  "serde",
@@ -17,13 +18,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.7.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
- "getrandom",
+ "cfg-if",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -34,6 +36,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anstream"
@@ -86,48 +94,48 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
+checksum = "369cfaf2a5bed5d8f8202073b2e093c9f508251de1551a0deb4253e4c7d80909"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "bytes_io"
-version = "0.0.0"
-source = "git+https://github.com/Greatness7/tes3#e3b0d8c01de9aa079f1d822b1c9966dd2afbc42d"
+version = "0.0.1"
+source = "git+https://github.com/Greatness7/tes3?branch=dev#9d670bda8f0e2c815f5891ac5545b3df7fb5947c"
 dependencies = [
  "bstr",
  "bytemuck",
  "bytes_io_macros",
- "copyless",
  "encoding_rs",
  "hashbrown",
  "memchr",
@@ -136,12 +144,18 @@ dependencies = [
 
 [[package]]
 name = "bytes_io_macros"
-version = "0.0.0"
-source = "git+https://github.com/Greatness7/tes3#e3b0d8c01de9aa079f1d822b1c9966dd2afbc42d"
+version = "0.0.1"
+source = "git+https://github.com/Greatness7/tes3?branch=dev#9d670bda8f0e2c815f5891ac5545b3df7fb5947c"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
+
+[[package]]
+name = "cc"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 
 [[package]]
 name = "cfg-if"
@@ -189,10 +203,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
-name = "copyless"
-version = "0.1.5"
+name = "cow-utils"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
+checksum = "417bef24afe1460300965a25ff4a24b8b45ad011948302ec221e8a0a81eb2c79"
 
 [[package]]
 name = "crossbeam-deque"
@@ -215,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "derive_more"
@@ -234,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "encoding_rs"
@@ -249,47 +263,39 @@ dependencies = [
 
 [[package]]
 name = "esp"
-version = "0.0.0"
-source = "git+https://github.com/Greatness7/tes3#e3b0d8c01de9aa079f1d822b1c9966dd2afbc42d"
+version = "0.0.1"
+source = "git+https://github.com/Greatness7/tes3?branch=dev#9d670bda8f0e2c815f5891ac5545b3df7fb5947c"
 dependencies = [
  "bitflags",
  "bstr",
  "bytemuck",
  "bytes_io",
+ "cow-utils",
  "derive_more",
  "esp_macros",
  "hashbrown",
+ "itoa",
  "rayon",
  "smart-default",
 ]
 
 [[package]]
 name = "esp_macros"
-version = "0.0.0"
-source = "git+https://github.com/Greatness7/tes3#e3b0d8c01de9aa079f1d822b1c9966dd2afbc42d"
+version = "0.0.1"
+source = "git+https://github.com/Greatness7/tes3?branch=dev#9d670bda8f0e2c815f5891ac5545b3df7fb5947c"
 dependencies = [
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
+ "syn 2.0.66",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
  "rayon",
 ]
 
@@ -313,15 +319,34 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7bb23d733dfcc8af652a78b7bf232f0e967710d044732185e561e47c0336b6"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9186d86b79b52f4a77af65604b51225e8db1d6ee7e3f41aec1e40829c71a176"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "once_cell"
@@ -331,9 +356,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -413,28 +438,28 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -450,13 +475,13 @@ dependencies = [
 
 [[package]]
 name = "smart-default"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133659a15339456eeeb07572eb02a91c91e9815e9cbc89566944d2c8d3efdbf6"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -478,9 +503,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -490,7 +515,7 @@ dependencies = [
 [[package]]
 name = "tes3"
 version = "0.0.1"
-source = "git+https://github.com/Greatness7/tes3#e3b0d8c01de9aa079f1d822b1c9966dd2afbc42d"
+source = "git+https://github.com/Greatness7/tes3?branch=dev#9d670bda8f0e2c815f5891ac5545b3df7fb5947c"
 dependencies = [
  "esp",
 ]
@@ -512,12 +537,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "windows-sys"
@@ -591,3 +610,23 @@ name = "windows_x86_64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,16 +8,19 @@ clap = "^4.5"
 levenshtein = "1.0.5"
 rayon = "1.10.0"
 regex = "^1.10"
+mimalloc = { version = "^0.1", default-features = false }
 
 [dependencies.tes3]
 git = "https://github.com/Greatness7/tes3"
+branch = "dev"
 default-features = false
+# features = ["esp", "nightly", "simd"]
 features = ["esp"]
 
-[build_dependencies]
+[build-dependencies]
 serde_json = "^1.0"
 regex = "^1.10"
 
-[build_dependencies.serde]
+[build-dependencies.serde]
 version = "^1.0"
 features = ["derive"]

--- a/build.rs
+++ b/build.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     write_supplies(Path::new(&out_dir).join("gen_supplies.rs"))?;
     write_travel(Path::new(&out_dir).join("gen_travel.rs"))?;
     write_uniques(Path::new(&out_dir).join("gen_uniques.rs"))?;
-    return Ok(());
+    Ok(())
 }
 
 trait FileWritable {
@@ -35,7 +35,7 @@ impl FileWritable for &str {
     fn write_to_file(&self, file: &mut File) -> Result<(), io::Error> {
         file.write_all(br##"r#""##)?;
         file.write_all(self.as_bytes())?;
-        return file.write_all(br##""#"##);
+        file.write_all(br##""#"##)
     }
 }
 
@@ -82,7 +82,7 @@ where
     T: FileWritable,
 {
     fn write_to_file(&self, file: &mut File) -> Result<(), io::Error> {
-        write_vec(file, self.iter(), &FileWritable::write_to_file)
+        write_vec(file, self.iter(), FileWritable::write_to_file)
     }
 }
 
@@ -97,7 +97,7 @@ fn parse_bodypart_rule(value: &Value, file: &mut File) -> Result<(), io::Error> 
     match value {
         Value::Array(rule) => {
             file.write_all(b"Rule::Array(")?;
-            write_vec(file, rule.iter(), &parse_bodypart_rule)?;
+            write_vec(file, rule.iter(), parse_bodypart_rule)?;
             return file.write_all(b")");
         }
         Value::Object(rule) => {
@@ -150,7 +150,7 @@ impl FileWritable for BodyPartDefinition {
         file.write_all(b",")?;
         if let Some(rules) = &self.rules {
             file.write_all(b"Some(")?;
-            write_vec(file, rules.iter(), &parse_bodypart_fields)?;
+            write_vec(file, rules.iter(), parse_bodypart_fields)?;
             file.write_all(b")")?;
         } else {
             file.write_all(b"None")?;
@@ -173,7 +173,7 @@ impl FileWritable for BodyParts {
             file.write_all(b"(")?;
             id.write_to_file(file)?;
             file.write_all(b",")?;
-            write_vec(file, ruleset.iter(), &parse_bodypart_fields)?;
+            write_vec(file, ruleset.iter(), parse_bodypart_fields)?;
             file.write_all(b")")
         })?;
         file.write_all(b",")?;
@@ -268,10 +268,7 @@ fn write_mwscript(path: PathBuf) -> Result<(), Box<dyn Error>> {
         return r""#,
     )?;
     let mut first = true;
-    for command in include_str!("./data/mwscript.returning.txt")
-        .trim()
-        .split_whitespace()
-    {
+    for command in include_str!("./data/mwscript.returning.txt").split_whitespace() {
         if first {
             first = false;
         } else {

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,18 +9,18 @@ pub enum Mode {
     Vanilla,
 }
 
-impl From<&String> for Mode {
-    fn from(value: &String) -> Self {
-        if value == "PT" {
-            return Mode::PT;
-        } else if value == "TD" {
-            return Mode::TD;
-        } else if value == "TR" {
-            return Mode::TR;
-        } else if value == "Vanilla" {
-            return Mode::Vanilla;
+impl<T> From<T> for Mode
+where
+    T: AsRef<str>,
+{
+    fn from(value: T) -> Self {
+        match value.as_ref() {
+            "PT" => Mode::PT,
+            "TD" => Mode::TD,
+            "TR" => Mode::TR,
+            "Vanilla" => Mode::Vanilla,
+            _ => Mode::None,
         }
-        return Mode::None;
     }
 }
 
@@ -32,7 +32,7 @@ pub struct Project {
 
 impl Project {
     pub fn matches(&self, id: &str) -> bool {
-        return ci_starts_with(id, &self.prefix);
+        ci_starts_with(id, self.prefix)
     }
 
     pub fn has_local(&self, id: &str) -> bool {
@@ -49,9 +49,9 @@ pub struct Context {
 
 impl Context {
     pub fn new(mode: Mode) -> Self {
-        return Context {
+        Context {
             mode,
             projects: get_project_data(),
-        };
+        }
     }
 }

--- a/src/extended/items.rs
+++ b/src/extended/items.rs
@@ -75,7 +75,7 @@ impl ExtendedHandler for OwnershipValidator {
                     if scale != 1. && self.items.contains(&lower) {
                         println!(
                             "Cell {} contains {} with scale {}",
-                            cell.editor_id(),
+                            name,
                             reference.id,
                             scale
                         );

--- a/src/extended/items.rs
+++ b/src/extended/items.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 
-use tes3::esp::TES3Object;
+use tes3::esp::{EditorId, LightFlags, TES3Object};
 
-use crate::util::{cannot_sleep, get_cell_name, is_empty};
+use crate::util::cannot_sleep;
 
 use super::ExtendedHandler;
 
@@ -12,13 +12,13 @@ pub struct OwnershipValidator {
 }
 
 impl ExtendedHandler for OwnershipValidator {
-    fn on_record(&mut self, record: &TES3Object, _: &str, id: &String, _: &str, last: bool) {
+    fn on_record(&mut self, record: &TES3Object, _: &str, id: &str, _: &str, last: bool) {
         match record {
             TES3Object::Activator(activator) => {
-                if let Some(script) = &activator.script {
-                    if script.eq_ignore_ascii_case("bed_standard") {
-                        self.ownable.insert(id.to_ascii_lowercase());
-                    }
+                if !activator.script.is_empty()
+                    && activator.script.eq_ignore_ascii_case("bed_standard")
+                {
+                    self.ownable.insert(id.to_ascii_lowercase());
                 }
             }
             TES3Object::Alchemy(_) => {
@@ -43,7 +43,7 @@ impl ExtendedHandler for OwnershipValidator {
                 self.items.insert(id.to_ascii_lowercase());
             }
             TES3Object::Light(light) => {
-                if light.can_carry() {
+                if light.data.flags.contains(LightFlags::CAN_CARRY) {
                     self.items.insert(id.to_ascii_lowercase());
                 }
             }
@@ -66,28 +66,37 @@ impl ExtendedHandler for OwnershipValidator {
                 if !last {
                     return;
                 }
-                let name = get_cell_name(cell);
                 let mut owned = 0;
                 let mut unowned = 0;
+                let name = cell.editor_id();
                 for reference in cell.references.values() {
                     let lower = reference.id.to_ascii_lowercase();
                     let scale = reference.scale.unwrap_or(1.);
                     if scale != 1. && self.items.contains(&lower) {
                         println!(
                             "Cell {} contains {} with scale {}",
-                            name, reference.id, scale
+                            cell.editor_id(),
+                            reference.id,
+                            scale
                         );
                     }
-                    if (reference.lock_level.is_some() || !is_empty(&reference.trap))
+
+                    let locked = reference.lock_level.is_some();
+                    let has_trap = matches!(&reference.trap, Some(s) if !s.is_empty());
+                    let has_owner = matches!(&reference.owner, Some(s) if !s.is_empty());
+                    let has_owner_faction =
+                        matches!(&reference.owner_faction, Some(s) if !s.is_empty());
+
+                    if (locked || has_trap)
                         || self.items.contains(&lower)
                         || self.ownable.contains(&lower)
                     {
-                        if !is_empty(&reference.owner) || !is_empty(&reference.owner_faction) {
+                        if has_owner || has_owner_faction {
                             owned += 1;
                         } else {
                             unowned += 1;
                         }
-                    } else if !is_empty(&reference.owner) || !is_empty(&reference.owner_faction) {
+                    } else if has_owner || has_owner_faction {
                         println!(
                             "Cell {} contains incorrectly owned object {}",
                             name, reference.id
@@ -109,9 +118,9 @@ impl ExtendedHandler for OwnershipValidator {
 
 impl OwnershipValidator {
     pub fn new() -> Self {
-        return Self {
+        Self {
             items: HashSet::new(),
             ownable: HashSet::new(),
-        };
+        }
     }
 }

--- a/src/extended/names.rs
+++ b/src/extended/names.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use levenshtein::levenshtein;
 use rayon::prelude::*;
-use tes3::esp::{Dialogue, Info, TES3Object};
+use tes3::esp::{Dialogue, DialogueInfo, QuestState, TES3Object};
 
 use super::ExtendedHandler;
 
@@ -17,56 +17,52 @@ pub struct QuestNameValidator {
 }
 
 impl ExtendedHandler for NameValidator {
-    fn on_record(&mut self, record: &TES3Object, _: &str, _: &String, _: &str, _: bool) {
+    fn on_record(&mut self, record: &TES3Object, _: &str, _: &str, _: &str, _: bool) {
         if let TES3Object::Npc(npc) = record {
-            if let Some(name) = &npc.name {
-                let min_distance = (name.len() as f32 / DISTANCE_DIV).round() as usize;
-                if min_distance < 1 {
-                    return;
-                }
-                let lower = name.to_ascii_lowercase();
-                let found = self.names.par_iter().find_map_any(|element| {
-                    let (other_name, _) = element;
-                    if *other_name == *lower {
-                        return None;
-                    }
-                    let distance = levenshtein(&lower, other_name);
-                    if distance > min_distance {
-                        return None;
-                    }
-                    return Some((element, distance));
-                });
-                if let Some(((other_name, id), distance)) = found {
-                    println!(
-                        "Npc {} ({}) has a name similar to {} ({}) {}",
-                        npc.id, name, id, other_name, distance
-                    );
-                }
-                self.names.push((lower, npc.id.clone()));
+            let min_distance = (npc.name.len() as f32 / DISTANCE_DIV).round() as usize;
+            if min_distance < 1 {
+                return;
             }
+            let lower = npc.name.to_ascii_lowercase();
+            let found = self.names.par_iter().find_map_any(|element| {
+                let (other_name, _) = element;
+                if *other_name == *lower {
+                    return None;
+                }
+                let distance = levenshtein(&lower, other_name);
+                if distance > min_distance {
+                    return None;
+                }
+                Some((element, distance))
+            });
+            if let Some(((other_name, id), distance)) = found {
+                println!(
+                    "Npc {} ({}) has a name similar to {} ({}) {}",
+                    npc.id, npc.name, id, other_name, distance
+                );
+            }
+            self.names.push((lower, npc.id.clone()));
         }
     }
 }
 
 impl ExtendedHandler for QuestNameValidator {
-    fn on_info(&mut self, record: &Info, topic: &Dialogue, file: &str, last: bool) {
-        if record.quest_name.is_some() {
-            if let Some(name) = &record.text {
-                if name.is_empty() {
-                    return;
+    fn on_info(&mut self, record: &DialogueInfo, topic: &Dialogue, file: &str, last: bool) {
+        if record.quest_state == Some(QuestState::Name) {
+            if record.text.is_empty() {
+                return;
+            }
+            let lower = record.text.to_ascii_lowercase();
+            if let Some((other_id, other_file)) = self.names.get(&lower) {
+                if last && other_file != file {
+                    println!(
+                        "Found quest {} ({}) in {} and {} ({})",
+                        record.text, topic.id, file, other_file, other_id
+                    );
                 }
-                let lower = name.to_ascii_lowercase();
-                if let Some((other_id, other_file)) = self.names.get(&lower) {
-                    if last && other_file != file {
-                        println!(
-                            "Found quest {} ({}) in {} and {} ({})",
-                            name, topic.id, file, other_file, other_id
-                        );
-                    }
-                } else {
-                    self.names
-                        .insert(lower, (topic.id.clone(), file.to_string()));
-                }
+            } else {
+                self.names
+                    .insert(lower, (topic.id.clone(), file.to_string()));
             }
         }
     }
@@ -74,14 +70,14 @@ impl ExtendedHandler for QuestNameValidator {
 
 impl NameValidator {
     pub fn new() -> Self {
-        return Self { names: Vec::new() };
+        Self { names: Vec::new() }
     }
 }
 
 impl QuestNameValidator {
     pub fn new() -> Self {
-        return Self {
+        Self {
             names: HashMap::new(),
-        };
+        }
     }
 }

--- a/src/extended/weapons.rs
+++ b/src/extended/weapons.rs
@@ -1,15 +1,12 @@
 use std::collections::HashMap;
 
-use tes3::esp::TES3Object;
+use tes3::esp::{TES3Object, WeaponFlags};
 
 use super::ExtendedHandler;
 
 pub struct WeaponValidator {
     weapons: HashMap<String, BaseWeapon>,
 }
-
-const IGNORES_RESIST: u32 = 1;
-const SILVER: u32 = 2;
 
 struct BaseWeapon {
     ignores: Option<bool>,
@@ -18,52 +15,49 @@ struct BaseWeapon {
 }
 
 impl ExtendedHandler for WeaponValidator {
-    fn on_record(&mut self, record: &TES3Object, _: &str, _: &String, _: &str, last: bool) {
+    fn on_record(&mut self, record: &TES3Object, _: &str, _: &str, _: &str, last: bool) {
         if let TES3Object::Weapon(weapon) = record {
-            if let Some(name) = &weapon.name {
-                if name.eq_ignore_ascii_case("<deprecated>") {
-                    return;
-                }
+            if weapon.name.eq_ignore_ascii_case("<deprecated>") {
+                return;
             }
-            if let Some(mesh) = &weapon.mesh {
-                let flags = weapon.data.as_ref().map(|d| d.flags).unwrap_or(0);
-                let ignores;
-                if weapon.enchanting.is_none() {
-                    ignores = Some((flags & IGNORES_RESIST) != 0);
-                } else {
-                    ignores = None;
-                }
-                let silver = (flags & SILVER) != 0;
-                let lower = mesh.to_ascii_lowercase();
-                if let Some(base) = self.weapons.get_mut(&lower) {
-                    if base.id.eq_ignore_ascii_case(&weapon.id) {
-                        base.silver = silver;
-                        base.ignores = ignores;
-                    } else if base.ignores.is_none() && weapon.enchanting.is_none() {
-                        base.silver = silver;
-                        base.ignores = ignores;
-                        base.id = weapon.id.clone();
-                    } else if last {
-                        if base.silver != silver {
-                            println!(
-                                "Weapon {} has a different silver value than {}",
-                                weapon.id, base.id
-                            );
-                        }
-                        if base.ignores != ignores && base.ignores.is_some() && ignores.is_some() {
-                            println!("Weapon {} has a different ignores normal weapon resistance value than {}", weapon.id, base.id);
-                        }
+            let mesh = &weapon.mesh;
+            let flags = weapon.data.flags;
+
+            let ignores = if weapon.enchanting.is_empty() {
+                Some(flags.contains(WeaponFlags::IGNORES_NORMAL_WEAPON_RESISTANCE))
+            } else {
+                None
+            };
+            let silver = flags.contains(WeaponFlags::SILVER);
+            let lower = mesh.to_ascii_lowercase();
+            if let Some(base) = self.weapons.get_mut(&lower) {
+                if base.id.eq_ignore_ascii_case(&weapon.id) {
+                    base.silver = silver;
+                    base.ignores = ignores;
+                } else if base.ignores.is_none() && weapon.enchanting.is_empty() {
+                    base.silver = silver;
+                    base.ignores = ignores;
+                    base.id = weapon.id.clone();
+                } else if last {
+                    if base.silver != silver {
+                        println!(
+                            "Weapon {} has a different silver value than {}",
+                            weapon.id, base.id
+                        );
                     }
-                } else {
-                    self.weapons.insert(
-                        mesh.to_ascii_lowercase(),
-                        BaseWeapon {
-                            ignores,
-                            silver,
-                            id: weapon.id.clone(),
-                        },
-                    );
+                    if base.ignores != ignores && base.ignores.is_some() && ignores.is_some() {
+                        println!("Weapon {} has a different ignores normal weapon resistance value than {}", weapon.id, base.id);
+                    }
                 }
+            } else {
+                self.weapons.insert(
+                    mesh.to_ascii_lowercase(),
+                    BaseWeapon {
+                        ignores,
+                        silver,
+                        id: weapon.id.clone(),
+                    },
+                );
             }
         }
     }
@@ -71,8 +65,8 @@ impl ExtendedHandler for WeaponValidator {
 
 impl WeaponValidator {
     pub fn new() -> Self {
-        return Self {
+        Self {
             weapons: HashMap::new(),
-        };
+        }
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,7 +1,7 @@
 use crate::context::{Context, Mode};
 use clap::ArgMatches;
 use std::error::Error;
-use tes3::esp::{Cell, Dialogue, FixedString, Info, Reference, TES3Object};
+use tes3::esp::{Cell, Dialogue, DialogueInfo, FixedString, Reference, TES3Object};
 
 #[allow(unused_variables)]
 pub trait Handler<'a> {
@@ -10,7 +10,7 @@ pub trait Handler<'a> {
         context: &Context,
         record: &'a TES3Object,
         typename: &'static str,
-        id: &String,
+        id: &str,
     ) {
     }
 
@@ -19,8 +19,8 @@ pub trait Handler<'a> {
         context: &Context,
         record: &'a Cell,
         reference: &Reference,
-        id: &String,
-        refs: &Vec<&Reference>,
+        id: &str,
+        refs: &[&Reference],
         i: usize,
     ) {
     }
@@ -35,7 +35,7 @@ pub trait Handler<'a> {
     ) {
     }
 
-    fn on_info(&mut self, context: &Context, record: &'a Info, topic: &Dialogue) {}
+    fn on_info(&mut self, context: &Context, record: &'a DialogueInfo, topic: &Dialogue) {}
 
     fn on_scriptline(
         &mut self,
@@ -90,7 +90,7 @@ impl Handlers<'_> {
                 crate::validators::uniques::UniquesValidator::new()?
             ));
         }
-        return Ok(Handlers { handlers });
+        Ok(Handlers { handlers })
     }
 }
 
@@ -100,10 +100,10 @@ impl<'a> Handler<'a> for Handlers<'a> {
         context: &Context,
         record: &'a TES3Object,
         typename: &'static str,
-        id: &String,
+        id: &str,
     ) {
         for handler in &mut self.handlers {
-            handler.on_record(context, record, typename, &id);
+            handler.on_record(context, record, typename, id);
         }
     }
 
@@ -112,8 +112,8 @@ impl<'a> Handler<'a> for Handlers<'a> {
         context: &Context,
         record: &'a Cell,
         reference: &Reference,
-        id: &String,
-        refs: &Vec<&Reference>,
+        id: &str,
+        refs: &[&Reference],
         i: usize,
     ) {
         for handler in &mut self.handlers {
@@ -121,7 +121,7 @@ impl<'a> Handler<'a> for Handlers<'a> {
         }
     }
 
-    fn on_info(&mut self, context: &Context, record: &'a Info, topic: &Dialogue) {
+    fn on_info(&mut self, context: &Context, record: &'a DialogueInfo, topic: &Dialogue) {
         for handler in &mut self.handlers {
             handler.on_info(context, record, topic);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,9 +96,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .map_or(Mode::None, Mode::from);
 
     let context = Context::new(mode);
-    validate(paths.next().unwrap(), context, &args).unwrap();
-
-    Ok(())
+    validate(paths.next().unwrap(), context, &args)
 }
 
 fn validate(path: &str, context: Context, args: &ArgMatches) -> Result<(), Box<dyn Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,9 @@ mod oob;
 mod util;
 mod validators;
 
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 fn main() -> Result<(), Box<dyn Error>> {
     let args = Command::new("validator")
         .args(&[
@@ -43,14 +46,14 @@ fn main() -> Result<(), Box<dyn Error>> {
             Arg::new("mininhabitants")
                 .value_name("number")
                 .default_value("3")
-                .value_parser(&str::parse::<usize>)
+                .value_parser(str::parse::<usize>)
                 .long("min-inhabitants")
                 .help("Minimum number of inhabitants a dungeon cell should have.")
                 .requires("extended"),
             Arg::new("duplicatethreshold")
                 .long("duplicate-threshold")
                 .default_value("0")
-                .value_parser(&str::parse::<f32>)
+                .value_parser(str::parse::<f32>)
                 .value_name("threshold")
                 .help(
                     "Squared distance at which two objects with the same id, \
@@ -78,6 +81,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         ])
         .get_matches();
     let mut paths = args.get_many::<String>("path").unwrap();
+
     if args.get_flag("extended") || args.get_flag("names") {
         return Ok(run_extended(paths.collect(), &args)?);
     }
@@ -87,15 +91,17 @@ fn main() -> Result<(), Box<dyn Error>> {
     if let Some(output) = args.get_one::<String>("ooboutput") {
         return run_oob_fixes(paths.next().unwrap(), output);
     }
-    let mode: Mode = args
+    let mode = args
         .get_one::<String>("mode")
-        .unwrap_or(&String::new())
-        .into();
+        .map_or(Mode::None, Mode::from);
+
     let context = Context::new(mode);
-    return validate(paths.next().unwrap(), context, &args);
+    validate(paths.next().unwrap(), context, &args).unwrap();
+
+    Ok(())
 }
 
-fn validate(path: &String, context: Context, args: &ArgMatches) -> Result<(), Box<dyn Error>> {
+fn validate(path: &str, context: Context, args: &ArgMatches) -> Result<(), Box<dyn Error>> {
     let plugin = load_plugin(path)?;
     let mut validator = Validator::new(context, args)?;
     validator.validate(&plugin.objects);
@@ -107,13 +113,9 @@ fn load_plugin(p: impl AsRef<Path>) -> Result<Plugin, String> {
     let mut plugin = Plugin::new();
     let result = plugin.load_path(path);
     if let Some(err) = result.err() {
-        return Err(format!(
-            "Failed to load {} ({})",
-            path.display(),
-            err.to_string()
-        ));
+        return Err(format!("Failed to load {} ({})", path.display(), err));
     }
-    return Ok(plugin);
+    Ok(plugin)
 }
 
 fn run_extended(paths: Vec<&String>, args: &ArgMatches) -> Result<(), String> {
@@ -124,10 +126,8 @@ fn run_extended(paths: Vec<&String>, args: &ArgMatches) -> Result<(), String> {
     let autoload = !args.get_flag("dontautoload");
     if autoload {
         if let Some(header) = plugin.header() {
-            if let Some(masters) = &header.masters {
-                for (file, _) in masters {
-                    auto_discovered.push(file);
-                }
+            for (file, _) in &header.masters {
+                auto_discovered.push(file);
             }
         }
     }
@@ -153,9 +153,9 @@ fn run_extended(paths: Vec<&String>, args: &ArgMatches) -> Result<(), String> {
     Ok(())
 }
 
-fn run_oob_fixes(input: &String, output: &String) -> Result<(), Box<dyn Error>> {
+fn run_oob_fixes(input: &str, output: &str) -> Result<(), Box<dyn Error>> {
     let mut plugin = load_plugin(input)?;
-    fix_oob(&mut plugin.objects);
+    fix_oob(&mut plugin);
     plugin.save_path(output)?;
     Ok(())
 }

--- a/src/oob.rs
+++ b/src/oob.rs
@@ -14,6 +14,10 @@ pub fn fix_oob(plugin: &mut Plugin) {
 
     for (grid, cell) in &exteriors {
         for (key, reference) in &cell.references {
+            if reference.deleted == Some(true) {
+                continue;
+            }
+
             let [x, y, _] = reference.translation;
             let actual_grid = get_cell_grid(x as f64, y as f64);
             let dx = (grid.0 - actual_grid.0).abs();

--- a/src/oob.rs
+++ b/src/oob.rs
@@ -1,67 +1,65 @@
 use std::collections::HashMap;
 
-use tes3::esp::{Cell, TES3Object};
+use tes3::esp::{Cell, Plugin};
 
-use crate::util::{get_cell_grid, get_cell_name};
+use crate::util::get_cell_grid;
 
-fn build_grid_map(records: &mut Vec<TES3Object>) -> HashMap<(i32, i32), *mut Cell> {
-    let mut out: HashMap<(i32, i32), *mut Cell> = HashMap::new();
-    for record in records {
-        if let TES3Object::Cell(cell) = record {
-            if cell.is_exterior() {
-                out.insert(cell.data.grid, cell);
+pub fn fix_oob(plugin: &mut Plugin) {
+    let mut exteriors: HashMap<_, _> = plugin
+        .objects_of_type_mut::<Cell>()
+        .filter_map(|cell| Some((cell.exterior_coords()?, cell)))
+        .collect();
+
+    let mut out_of_bounds = vec![];
+
+    for (grid, cell) in &exteriors {
+        for (key, reference) in &cell.references {
+            let [x, y, _] = reference.translation;
+            let actual_grid = get_cell_grid(x as f64, y as f64);
+            let dx = (grid.0 - actual_grid.0).abs();
+            let dy = (grid.1 - actual_grid.1).abs();
+
+            // In the correct cell
+            if dx == 0 && dy == 0 {
+                continue;
             }
-        }
-    }
-    return out;
-}
 
-pub fn fix_oob(records: &mut Vec<TES3Object>) {
-    let cells = build_grid_map(records);
-    for cr in cells.values() {
-        let cell = *cr;
-        unsafe {
-            (*cell).references.retain(|key, reference| {
-                if reference.deleted.unwrap_or(false) {
-                    return true;
-                }
-                let [x, y, _] = reference.translation;
-                let actual_grid = get_cell_grid(x as f64, y as f64);
-                let dx = ((*cell).data.grid.0 - actual_grid.0).abs();
-                let dy = ((*cell).data.grid.1 - actual_grid.1).abs();
-                if dx > 1 || dy > 1 {
-                    println!(
-                        "Not moving {} from {} as [{}, {}] is too far away",
-                        reference.id,
-                        get_cell_name(&*cell),
-                        actual_grid.0,
-                        actual_grid.1
-                    );
-                } else if dx > 0 || dy > 0 {
-                    if let Some(target_cell) = cells.get(&actual_grid) {
-                        println!(
-                            "Moving {} from {} to [{}, {}]",
-                            reference.id,
-                            get_cell_name(&*cell),
-                            actual_grid.0,
-                            actual_grid.1
-                        );
-                        (*(*target_cell))
-                            .references
-                            .insert(key.clone(), reference.clone());
-                        return false;
-                    } else {
-                        println!(
-                            "Not moving {} from {} as cell [{}, {}] is not in this file",
-                            reference.id,
-                            get_cell_name(&*cell),
-                            actual_grid.0,
-                            actual_grid.1
-                        );
-                    }
-                }
-                return true;
-            });
+            // More then 1 cell away
+            if dx > 1 || dy > 1 {
+                println!(
+                    "Not moving {} {:?} from cell {:?} as cell {:?} is too far away",
+                    reference.id, key, grid, actual_grid
+                );
+                continue;
+            }
+
+            // In an undefined cell
+            if !exteriors.contains_key(&actual_grid) {
+                println!(
+                    "Not moving {} {:?} from cell {:?} as cell {:?} is not in this file",
+                    reference.id, key, grid, actual_grid
+                );
+                continue;
+            }
+
+            // In a neighboring cell
+            println!(
+                "Moving {} {:?} from {:?} to {:?}",
+                reference.id, key, grid, actual_grid
+            );
+            out_of_bounds.push((*grid, actual_grid, *key));
         }
     }
+
+    out_of_bounds
+        .into_iter()
+        .try_for_each(|(old_grid, new_grid, key)| {
+            let old_cell = exteriors.get_mut(&old_grid)?;
+            let reference = old_cell.references.remove(&key)?;
+
+            let new_cell = exteriors.get_mut(&new_grid)?;
+            new_cell.references.insert(key, reference);
+
+            Some(())
+        });
 }

--- a/src/oob.rs
+++ b/src/oob.rs
@@ -24,7 +24,7 @@ pub fn fix_oob(plugin: &mut Plugin) {
                 continue;
             }
 
-            // More then 1 cell away
+            // More than 1 cell away
             if dx > 1 || dy > 1 {
                 println!(
                     "Not moving {} {:?} from cell {:?} as cell {:?} is too far away",

--- a/src/validators/autocalc.rs
+++ b/src/validators/autocalc.rs
@@ -1,18 +1,14 @@
 use super::Context;
 use crate::handlers::Handler;
-use tes3::esp::TES3Object;
-
-const FLAG_SPELL_AUTO_CALC: u32 = 1;
+use tes3::esp::{SpellFlags, TES3Object};
 
 pub struct AutoCalcValidator {}
 
 impl Handler<'_> for AutoCalcValidator {
-    fn on_record(&mut self, _: &Context, record: &TES3Object, _: &str, _: &String) {
+    fn on_record(&mut self, _: &Context, record: &TES3Object, _: &str, _: &str) {
         if let TES3Object::Spell(spell) = record {
-            if let Some(data) = &spell.data {
-                if (data.flags & FLAG_SPELL_AUTO_CALC) != 0 {
-                    println!("Spell {} is auto calculated", spell.id);
-                }
+            if spell.data.flags.contains(SpellFlags::AUTO_CALCULATE) {
+                println!("Spell {} is auto calculated", spell.id);
             }
         }
     }

--- a/src/validators/cells.rs
+++ b/src/validators/cells.rs
@@ -177,7 +177,7 @@ impl Handler<'_> for CellValidator {
                     .iter()
                     .any(|id| id.eq_ignore_ascii_case(&reference.id))
             {
-                let name = record.editor_id(); // TODO: verify
+                let name = record.editor_id();
                 let key = format!("{}_{}", name, id);
                 if self.seen.insert(key) {
                     println!(

--- a/src/validators/corpse.rs
+++ b/src/validators/corpse.rs
@@ -8,7 +8,7 @@ use tes3::esp::TES3Object;
 pub struct CorpseValidator {}
 
 impl Handler<'_> for CorpseValidator {
-    fn on_record(&mut self, _: &Context, record: &TES3Object, typename: &str, id: &String) {
+    fn on_record(&mut self, _: &Context, record: &TES3Object, typename: &str, id: &str) {
         if is_dead(record) && !is_persistent(record) {
             println!(
                 "{} {} is dead but does not have corpse persists checked",

--- a/src/validators/doors.rs
+++ b/src/validators/doors.rs
@@ -1,16 +1,14 @@
 use super::Context;
-use crate::{handlers::Handler, util::get_cell_name};
-use tes3::esp::{Cell, Reference, TES3Object};
+use crate::handlers::Handler;
+use tes3::esp::{Cell, EditorId, Reference, TES3Object};
 
 pub struct DoorValidator {}
 
 impl Handler<'_> for DoorValidator {
-    fn on_record(&mut self, _: &Context, record: &TES3Object, _: &str, _: &String) {
+    fn on_record(&mut self, _: &Context, record: &TES3Object, _: &str, _: &str) {
         if let TES3Object::Door(door) = record {
-            if let Some(mesh) = &door.mesh {
-                if mesh.eq_ignore_ascii_case("i\\in_lava_blacksquare.nif") {
-                    println!("Door {} uses mesh {}", door.id, mesh);
-                }
+            if door.mesh.eq_ignore_ascii_case("i\\in_lava_blacksquare.nif") {
+                println!("Door {} uses mesh {}", door.id, door.mesh);
             }
         }
     }
@@ -20,14 +18,15 @@ impl Handler<'_> for DoorValidator {
         _: &Context,
         record: &Cell,
         reference: &Reference,
-        id: &String,
-        _: &Vec<&Reference>,
+        id: &str,
+        _: &[&Reference],
         _: usize,
     ) {
-        if id == "prisonmarker" && reference.door_destination_cell.is_none() {
+        // TODO: G7 verify this makes sense
+        if id == "prisonmarker" && reference.destination.is_none() {
             println!(
                 "Cell {} contains an unlinked {}",
-                get_cell_name(record),
+                record.editor_id(),
                 reference.id
             );
         }

--- a/src/validators/doors.rs
+++ b/src/validators/doors.rs
@@ -22,7 +22,6 @@ impl Handler<'_> for DoorValidator {
         _: &[&Reference],
         _: usize,
     ) {
-        // TODO: G7 verify this makes sense
         if id == "prisonmarker" && reference.destination.is_none() {
             println!(
                 "Cell {} contains an unlinked {}",

--- a/src/validators/duplicates.rs
+++ b/src/validators/duplicates.rs
@@ -1,20 +1,10 @@
 use super::Context;
-use crate::{handlers::Handler, util::get_cell_name};
+use crate::handlers::Handler;
 use clap::ArgMatches;
-use rayon::prelude::*;
-use tes3::esp::{Cell, Reference};
+use tes3::esp::{Cell, EditorId, Reference};
 
 pub struct DuplicateRefValidator {
     threshold: f32,
-}
-
-fn equals(a: &[f32; 3], b: &[f32; 3]) -> bool {
-    for i in 0..a.len() {
-        if a[i] != b[i] {
-            return false;
-        }
-    }
-    return true;
 }
 
 impl Handler<'_> for DuplicateRefValidator {
@@ -23,37 +13,31 @@ impl Handler<'_> for DuplicateRefValidator {
         _: &Context,
         record: &Cell,
         reference: &Reference,
-        _: &String,
-        refs: &Vec<&Reference>,
+        _: &str,
+        refs: &[&Reference],
         i: usize,
     ) {
-        if reference.deleted.unwrap_or(false) {
+        if reference.deleted == Some(true) {
             return;
         }
-        unsafe { refs.get_unchecked(i + 1..) }
-            .par_iter()
-            .for_each(|other| {
-                if other.deleted.unwrap_or(false) {
-                    return;
-                }
-                if other.id.eq_ignore_ascii_case(&reference.id)
-                    && equals(&reference.rotation, &other.rotation)
-                    && reference.scale.unwrap_or(1.) == other.scale.unwrap_or(1.)
-                    && self.translation(&reference.translation, &other.translation)
-                {
-                    println!(
-                    "Cell {} contains duplicate reference {} at position [{}, {}, {}] [{}, {}, {}]",
-                    get_cell_name(record),
+        for other in &refs[i + 1..] {
+            if other.deleted == Some(true) {
+                continue;
+            }
+            if other.id.eq_ignore_ascii_case(&reference.id)
+                && reference.rotation == other.rotation
+                && reference.scale.unwrap_or(1.) == other.scale.unwrap_or(1.)
+                && self.translation(reference.translation, other.translation)
+            {
+                println!(
+                    "Cell {} contains duplicate reference {} at position {:?} {:?}",
+                    record.editor_id(),
                     reference.id,
-                    reference.translation[0],
-                    reference.translation[1],
-                    reference.translation[2],
-                    other.translation[0],
-                    other.translation[1],
-                    other.translation[2]
+                    reference.translation,
+                    other.translation,
                 );
-                }
-            });
+            }
+        }
     }
 }
 
@@ -63,16 +47,16 @@ impl DuplicateRefValidator {
             .get_one::<f32>("duplicatethreshold")
             .unwrap_or(&0.)
             .max(0.);
-        return DuplicateRefValidator { threshold };
+        DuplicateRefValidator { threshold }
     }
 
-    fn translation(&self, a: &[f32; 3], b: &[f32; 3]) -> bool {
+    fn translation(&self, a: [f32; 3], b: [f32; 3]) -> bool {
         if self.threshold == 0. {
-            return equals(a, b);
+            return a == b;
         }
         let [x1, y1, z1] = a;
         let [x2, y2, z2] = b;
         let d2 = (x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2) + (z1 - z2) * (z1 - z2);
-        return d2.abs() <= self.threshold;
+        d2.abs() <= self.threshold
     }
 }

--- a/src/validators/ids.rs
+++ b/src/validators/ids.rs
@@ -71,15 +71,12 @@ impl Handler<'_> for IdValidator {
         match record {
             TES3Object::Bodypart(part) => {
                 if is_vampire_head(part) {
-                    let prefix = "b_v_";
-                    let suffix = if is_female(part) {
-                        "f_head_01"
-                    } else {
-                        "m_head_01"
-                    };
-
-                    let id = part.id.to_ascii_lowercase();
-                    if !(id.starts_with(prefix) && id.ends_with(suffix)) {
+                    let id = format!(
+                        "b_v_{}_{}_head_01",
+                        part.id,
+                        if is_female(part) { "f" } else { "m" }
+                    );
+                    if !part.id.eq_ignore_ascii_case(&id) {
                         println!("Bodypart {} should have id {}", part.id, id);
                     }
                 } else {

--- a/src/validators/ids.rs
+++ b/src/validators/ids.rs
@@ -35,11 +35,11 @@ const VANILLA_FACTIONS: [&str; 27] = [
 ];
 
 fn is_female(part: &Bodypart) -> bool {
-    (part.data.female & 1) != 0
+    part.data.female
 }
 
 fn is_vampire_head(part: &Bodypart) -> bool {
-    (part.data.vampire != 0) && (part.data.part == BodypartId::Head)
+    part.data.vampire && (part.data.part == BodypartId::Head)
 }
 
 fn check_id(context: &Context, t: &str, id: &str) {

--- a/src/validators/ids.rs
+++ b/src/validators/ids.rs
@@ -35,20 +35,14 @@ const VANILLA_FACTIONS: [&str; 27] = [
 ];
 
 fn is_female(part: &Bodypart) -> bool {
-    if let Some(data) = &part.data {
-        return (data.female & 1) != 0;
-    }
-    return false;
+    (part.data.female & 1) != 0
 }
 
 fn is_vampire_head(part: &Bodypart) -> bool {
-    if let Some(data) = &part.data {
-        return data.vampire != 0 && data.part == BodypartId::Head;
-    }
-    return false;
+    (part.data.vampire != 0) && (part.data.part == BodypartId::Head)
 }
 
-fn check_id(context: &Context, t: &str, id: &String) {
+fn check_id(context: &Context, t: &str, id: &str) {
     let matching = context.projects.iter().find(|p| p.matches(id));
     match matching {
         Some(project) => {
@@ -72,17 +66,20 @@ impl Handler<'_> for IdValidator {
         context: &Context,
         record: &TES3Object,
         typename: &'static str,
-        id: &String,
+        id: &str,
     ) {
         match record {
             TES3Object::Bodypart(part) => {
-                if part.name.is_some() && is_vampire_head(part) {
-                    let id = format!(
-                        "b_v_{}_{}_head_01",
-                        part.name.as_ref().unwrap(),
-                        if is_female(part) { "f" } else { "m" }
-                    );
-                    if part.id != id {
+                if is_vampire_head(part) {
+                    let prefix = "b_v_";
+                    let suffix = if is_female(part) {
+                        "f_head_01"
+                    } else {
+                        "m_head_01"
+                    };
+
+                    let id = part.id.to_ascii_lowercase();
+                    if !(id.starts_with(prefix) && id.ends_with(suffix)) {
                         println!("Bodypart {} should have id {}", part.id, id);
                     }
                 } else {
@@ -95,7 +92,7 @@ impl Handler<'_> for IdValidator {
                 self.check_known(typename, id);
             }
             TES3Object::Faction(faction) => {
-                if context.mode != Mode::TD || !VANILLA_FACTIONS.contains(&id.as_str()) {
+                if context.mode != Mode::TD || !VANILLA_FACTIONS.contains(&id) {
                     check_id(context, typename, &faction.id);
                     self.check_known(typename, id);
                 }
@@ -103,7 +100,7 @@ impl Handler<'_> for IdValidator {
             TES3Object::GameSetting(_) => {
                 println!("Found dirty {} {}", typename, id);
             }
-            TES3Object::Info(_) => {}
+            TES3Object::DialogueInfo(_) => {}
             TES3Object::PathGrid(_) => {}
             TES3Object::Region(_) => {
                 self.check_known(typename, id);
@@ -123,12 +120,12 @@ impl Handler<'_> for IdValidator {
 
 impl IdValidator {
     pub fn new() -> Self {
-        return Self {
+        Self {
             known: HashMap::new(),
-        };
+        }
     }
 
-    fn check_known(&mut self, typename: &'static str, id: &String) {
+    fn check_known(&mut self, typename: &'static str, id: &str) {
         if let Some(prev) = self.known.insert(id.to_ascii_lowercase(), typename) {
             println!(
                 "{} {} shares its ID with a record of type {}",

--- a/src/validators/ids.rs
+++ b/src/validators/ids.rs
@@ -73,7 +73,7 @@ impl Handler<'_> for IdValidator {
                 if is_vampire_head(part) {
                     let id = format!(
                         "b_v_{}_{}_head_01",
-                        part.id,
+                        part.race,
                         if is_female(part) { "f" } else { "m" }
                     );
                     if !part.id.eq_ignore_ascii_case(&id) {

--- a/src/validators/missing.rs
+++ b/src/validators/missing.rs
@@ -1,23 +1,21 @@
 use super::Context;
 use crate::{handlers::Handler, util::is_marker};
-use tes3::esp::TES3Object;
+use tes3::esp::{LightFlags, TES3Object};
 
 pub struct FieldValidator {}
 
-fn check(typename: &str, id: &String, field: &str, value: &Option<String>) {
-    if let Some(str) = value {
-        if !str.trim().is_empty() {
-            if field != "name" && !str.contains('.') {
-                println!("{} {} has invalid {} {}", typename, id, field, str);
-            }
-            return;
+fn check(typename: &str, id: &str, field: &str, value: &str) {
+    if !value.is_empty() && !value.trim().is_empty() {
+        if field != "name" && !value.contains('.') {
+            println!("{} {} has invalid {} {}", typename, id, field, value);
         }
+        return;
     }
     println!("{} {} has a missing {}", typename, id, field);
 }
 
 impl Handler<'_> for FieldValidator {
-    fn on_record(&mut self, _: &Context, record: &TES3Object, typename: &str, id: &String) {
+    fn on_record(&mut self, _: &Context, record: &TES3Object, typename: &str, id: &str) {
         match record {
             TES3Object::Activator(r) => {
                 check(typename, id, "mesh", &r.mesh);
@@ -65,7 +63,7 @@ impl Handler<'_> for FieldValidator {
                 check(typename, id, "name", &r.name);
             }
             TES3Object::Light(r) => {
-                if r.can_carry() {
+                if r.data.flags.contains(LightFlags::CAN_CARRY) {
                     check(typename, id, "icon", &r.icon);
                     check(typename, id, "mesh", &r.mesh);
                     check(typename, id, "name", &r.name);

--- a/src/validators/npc.rs
+++ b/src/validators/npc.rs
@@ -283,7 +283,7 @@ impl NpcValidator {
 
     fn check_part(&self, npc: &Npc, actual: &str, expected: &Option<&'static str>, name: &str) {
         if let Some(expid) = expected {
-            if !actual.is_empty() && expid.eq_ignore_ascii_case(actual) {
+            if expid.eq_ignore_ascii_case(actual) {
                 return;
             }
             println!("Npc {} is not using unique {} {}", npc.id, name, expid);

--- a/src/validators/npc.rs
+++ b/src/validators/npc.rs
@@ -6,7 +6,7 @@ use crate::{
     handlers::Handler,
     util::{is_autocalc, is_dead, update_or_insert},
 };
-use tes3::esp::{BodypartId, FixedString, Npc, TES3Object};
+use tes3::esp::{BodypartId, FixedString, Npc, NpcFlags, TES3Object};
 
 include!(concat!(env!("OUT_DIR"), "/gen_bodyparts.rs"));
 
@@ -17,7 +17,6 @@ pub struct NpcValidator {
     hairs: HashMap<&'static str, AllRules>,
 }
 
-const FLAG_NPC_FEMALE: u32 = 1;
 const BOUNTY_ALARM: i8 = 100;
 const HOSTILE: i8 = 70;
 const KHAJIIT_ANIMATIONS: [&str; 2] = ["t_els_ohmes-raht", "t_els_suthay"];
@@ -25,13 +24,10 @@ const KHAJIIT_F: &str = "epos_kha_upr_anim_f.nif";
 const KHAJIIT_M: &str = "epos_kha_upr_anim_m.nif";
 
 fn check_khajiit_animations(npc: &Npc) {
-    let requires_animations = npc
-        .race
-        .iter()
-        .any(|r| KHAJIIT_ANIMATIONS.contains(&r.to_ascii_lowercase().as_str()));
-    let mesh = npc.mesh.as_ref().map(&String::as_str).unwrap_or("");
+    let requires_animations = KHAJIIT_ANIMATIONS.contains(&npc.race.to_ascii_lowercase().as_str());
+    let mesh = &npc.mesh;
     if requires_animations {
-        let male = (npc.npc_flags.unwrap_or(0) & FLAG_NPC_FEMALE) == 0;
+        let male = !npc.npc_flags.contains(NpcFlags::FEMALE);
         let target = if male { KHAJIIT_M } else { KHAJIIT_F };
         if !mesh.eq_ignore_ascii_case(target) {
             println!("Npc {} is not using animation {}", npc.id, target);
@@ -42,7 +38,7 @@ fn check_khajiit_animations(npc: &Npc) {
 }
 
 impl Handler<'_> for NpcValidator {
-    fn on_record(&mut self, context: &Context, record: &TES3Object, _: &str, _: &String) {
+    fn on_record(&mut self, context: &Context, record: &TES3Object, _: &str, _: &str) {
         self.slave_bracers = 0;
         if let TES3Object::Npc(npc) = record {
             self.check_bodyparts(npc);
@@ -50,21 +46,18 @@ impl Handler<'_> for NpcValidator {
                 println!("Npc {} has auto calculated stats and spells", npc.id);
             }
             if !is_dead(record) {
-                if let Some(ai) = &npc.ai_data {
-                    if ai.fight >= HOSTILE && ai.alarm >= BOUNTY_ALARM {
-                        println!(
-                            "Npc {} reports crimes despite having {} fight",
-                            npc.id, ai.fight
-                        );
-                    }
-                    if ai.alarm < BOUNTY_ALARM
-                        && npc.class.iter().any(|c| c.eq_ignore_ascii_case("guard"))
-                    {
-                        println!(
-                            "Npc {} does not report crimes despite being a guard",
-                            npc.id
-                        );
-                    }
+                let ai = &npc.ai_data;
+                if ai.fight >= HOSTILE && ai.alarm >= BOUNTY_ALARM {
+                    println!(
+                        "Npc {} reports crimes despite having {} fight",
+                        npc.id, ai.fight
+                    );
+                }
+                if (ai.alarm < BOUNTY_ALARM) && npc.class.eq_ignore_ascii_case("guard") {
+                    println!(
+                        "Npc {} does not report crimes despite being a guard",
+                        npc.id
+                    );
                 }
             }
             check_khajiit_animations(npc);
@@ -95,7 +88,7 @@ enum Rule {
 }
 
 impl Rule {
-    fn test(&self, value: &String) -> bool {
+    fn test(&self, value: &str) -> bool {
         match self {
             Rule::Array(rules) => rules.iter().all(|r| r.test(value)),
             Rule::Negation(rule) => !rule.test(value),
@@ -117,8 +110,8 @@ trait Testable {
 impl Testable for FieldRule {
     fn test(&self, npc: &Npc) -> bool {
         match self {
-            FieldRule::Class(rule) => npc.class.as_ref().map(|c| rule.test(c)).unwrap_or(false),
-            FieldRule::Faction(rule) => npc.faction.as_ref().map(|f| rule.test(f)).unwrap_or(false),
+            FieldRule::Class(rule) => rule.test(&npc.class),
+            FieldRule::Faction(rule) => rule.test(&npc.faction),
             FieldRule::Id(rule) => rule.test(&npc.id),
         }
     }
@@ -168,12 +161,12 @@ struct RulesParser {
 
 impl RulesParser {
     fn new() -> Self {
-        return Self {
+        Self {
             uniques: HashMap::new(),
             heads: HashMap::new(),
             hairs: HashMap::new(),
             rulesets: HashMap::new(),
-        };
+        }
     }
 
     fn parse_rules(
@@ -203,15 +196,16 @@ impl RulesParser {
                 out.rules.push(FieldRules { rules: equality });
             }
         }
-        return Ok(out);
+        Ok(out)
     }
 
+    #[allow(clippy::type_complexity)]
     fn parse_part(
         &mut self,
         definitions: Vec<(
             &'static str,
-            std::option::Option<&'static str>,
-            std::option::Option<Vec<Vec<FieldRule>>>,
+            Option<&'static str>,
+            Option<Vec<Vec<FieldRule>>>,
         )>,
         part: BodypartId,
     ) -> Result<(), String> {
@@ -255,12 +249,12 @@ impl NpcValidator {
         parser.parse_rulesets(rulesets)?;
         parser.parse_part(head, BodypartId::Head)?;
         parser.parse_part(hair, BodypartId::Hair)?;
-        return Ok(Self {
+        Ok(Self {
             slave_bracers: 0,
             uniques: parser.uniques,
             heads: parser.heads,
             hairs: parser.hairs,
-        });
+        })
     }
 
     fn check_bodyparts(&self, npc: &Npc) {
@@ -275,32 +269,22 @@ impl NpcValidator {
     fn check_part_rules(
         &self,
         npc: &Npc,
-        part: &Option<String>,
+        part_id: &str,
         rules: &HashMap<&'static str, AllRules>,
         name: &str,
     ) {
-        if let Some(id) = part {
-            let bodypart = id.to_lowercase();
-            if let Some(rule) = rules.get(bodypart.as_str()) {
-                if !rule.test(npc) {
-                    println!("Npc {} is using {} {}", npc.id, name, id);
-                }
+        let bodypart = part_id.to_lowercase();
+        if let Some(rule) = rules.get(bodypart.as_str()) {
+            if !rule.test(npc) {
+                println!("Npc {} is using {} {}", npc.id, name, part_id);
             }
         }
     }
 
-    fn check_part(
-        &self,
-        npc: &Npc,
-        actual: &Option<String>,
-        expected: &Option<&'static str>,
-        name: &str,
-    ) {
+    fn check_part(&self, npc: &Npc, actual: &str, expected: &Option<&'static str>, name: &str) {
         if let Some(expid) = expected {
-            if let Some(actid) = actual {
-                if expid.eq_ignore_ascii_case(&actid) {
-                    return;
-                }
+            if !actual.is_empty() && expid.eq_ignore_ascii_case(actual) {
+                return;
             }
             println!("Npc {} is not using unique {} {}", npc.id, name, expid);
         }

--- a/src/validators/persistent.rs
+++ b/src/validators/persistent.rs
@@ -9,7 +9,7 @@ pub struct PersistentValidator {
 }
 
 impl Handler<'_> for PersistentValidator {
-    fn on_record(&mut self, _: &Context, record: &TES3Object, _: &str, id: &String) {
+    fn on_record(&mut self, _: &Context, record: &TES3Object, _: &str, id: &str) {
         if is_persistent(record) {
             match record {
                 TES3Object::Creature(_) => {}
@@ -26,8 +26,8 @@ impl Handler<'_> for PersistentValidator {
         _: &Context,
         _: &Cell,
         _: &Reference,
-        id: &String,
-        _: &Vec<&Reference>,
+        id: &str,
+        _: &[&Reference],
         _: usize,
     ) {
         if let Some(count) = self.counts.get_mut(id) {
@@ -42,8 +42,8 @@ impl Handler<'_> for PersistentValidator {
 
 impl PersistentValidator {
     pub fn new() -> Self {
-        return Self {
+        Self {
             counts: HashMap::new(),
-        };
+        }
     }
 }

--- a/src/validators/soundgens.rs
+++ b/src/validators/soundgens.rs
@@ -10,14 +10,15 @@ pub struct SoundGenValidator {
 }
 
 impl Handler<'_> for SoundGenValidator {
-    fn on_record(&mut self, _: &Context, record: &TES3Object, _: &str, _: &String) {
+    fn on_record(&mut self, _: &Context, record: &TES3Object, _: &str, _: &str) {
         if let TES3Object::Creature(creature) = record {
-            if creature.sound.is_none() {
+            if creature.sound.is_empty() {
                 self.to_check.push(creature.id.to_ascii_lowercase());
             }
         } else if let TES3Object::SoundGen(soundgen) = record {
-            if let Some(id) = &soundgen.creature {
-                self.sound_gens.insert(id.to_ascii_lowercase());
+            if !soundgen.creature.is_empty() {
+                self.sound_gens
+                    .insert(soundgen.creature.to_ascii_lowercase());
             }
         }
     }
@@ -33,9 +34,9 @@ impl Handler<'_> for SoundGenValidator {
 
 impl SoundGenValidator {
     pub fn new() -> Self {
-        return Self {
+        Self {
             sound_gens: HashSet::new(),
             to_check: Vec::new(),
-        };
+        }
     }
 }

--- a/src/validators/supplies.rs
+++ b/src/validators/supplies.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use super::Context;
-use crate::{handlers::Handler, util::get_cell_name};
-use tes3::esp::{Cell, Reference};
+use crate::handlers::Handler;
+use tes3::esp::{Cell, EditorId, Reference};
 
 include!(concat!(env!("OUT_DIR"), "/gen_supplies.rs"));
 
@@ -18,11 +18,11 @@ impl Handler<'_> for SupplyChestValidator {
         _: &Context,
         record: &Cell,
         reference: &Reference,
-        id: &String,
-        _: &Vec<&Reference>,
+        id: &str,
+        _: &[&Reference],
         _: usize,
     ) {
-        if let Some(faction) = self.chests.get(id.as_str()) {
+        if let Some(faction) = self.chests.get(id) {
             if !reference
                 .owner_faction
                 .as_ref()
@@ -31,7 +31,7 @@ impl Handler<'_> for SupplyChestValidator {
             {
                 println!(
                     "Cell {} contains {} not owned by the {}",
-                    get_cell_name(record),
+                    record.editor_id(),
                     reference.id,
                     faction
                 );
@@ -40,7 +40,7 @@ impl Handler<'_> for SupplyChestValidator {
                 if rank != 0 && rank != ALL_RANKS {
                     println!(
                         "Cell {} contains {} not available to all ranks",
-                        get_cell_name(record),
+                        record.editor_id(),
                         reference.id
                     );
                 }
@@ -51,8 +51,8 @@ impl Handler<'_> for SupplyChestValidator {
 
 impl SupplyChestValidator {
     pub fn new() -> Self {
-        return Self {
+        Self {
             chests: get_supplies_data(),
-        };
+        }
     }
 }

--- a/src/validators/todo.rs
+++ b/src/validators/todo.rs
@@ -19,7 +19,7 @@ impl Handler<'_> for ToDoValidator {
         if self.todo.is_match(comment) {
             if let TES3Object::Script(script) = record {
                 println!("Script {} contains comment {}", script.id, comment);
-            } else if let TES3Object::Info(info) = record {
+            } else if let TES3Object::DialogueInfo(info) = record {
                 println!(
                     "Info {} in topic {} contains comment {}",
                     info.id, topic.id, comment
@@ -34,6 +34,6 @@ impl ToDoValidator {
         let todo = RegexBuilder::new(r"(^(todo|fixme|to do|fix me))|(^|\s)merge")
             .case_insensitive(true)
             .build()?;
-        return Ok(Self { todo });
+        Ok(Self { todo })
     }
 }

--- a/src/validators/travel.rs
+++ b/src/validators/travel.rs
@@ -95,7 +95,6 @@ impl<'a> Handler<'a> for TravelValidator<'a> {
                         .insert(npc.id.to_ascii_lowercase(), Caravaner::new(npc));
                     return;
                 }
-                // TODO: no alloc (use 'uncased' library?)
                 if self
                     .classes
                     .contains(npc.class.to_ascii_lowercase().as_str())

--- a/src/validators/travel.rs
+++ b/src/validators/travel.rs
@@ -3,9 +3,9 @@ use std::collections::{HashMap, HashSet};
 use super::Context;
 use crate::{
     handlers::Handler,
-    util::{get_cell_grid, get_cell_name, is_dead, Actor},
+    util::{get_cell_grid, is_dead, Actor},
 };
-use tes3::esp::{Cell, Dialogue, Info, Reference, TES3Object, TravelDestination};
+use tes3::esp::{Cell, Dialogue, DialogueInfo, EditorId, Reference, TES3Object, TravelDestination};
 
 include!(concat!(env!("OUT_DIR"), "/gen_travel.rs"));
 
@@ -18,37 +18,34 @@ pub struct TravelValidator<'a> {
 struct Caravaner<'a> {
     record: &'a dyn Actor,
     cells: Vec<Location<'a>>,
-    destination: Vec<&'a Info>,
+    destination: Vec<&'a DialogueInfo>,
 }
 
-fn get_town_name(id: &String) -> &str {
+fn get_town_name(id: &str) -> &str {
     if let Some((prefix, _)) = id.split_once(",") {
         return prefix;
     }
-    return id.as_str();
+    id
 }
 
 impl<'a> Caravaner<'a> {
     pub fn new(record: &'a dyn Actor) -> Self {
-        return Self {
+        Self {
             record,
             cells: Vec::new(),
             destination: Vec::new(),
-        };
+        }
     }
 
     fn is_counterpart(&self, location: &Location) -> bool {
-        if let Some(destinations) = self.record.get_destinations() {
-            return destinations.iter().any(|d| location.matches(d));
-        }
-        return false;
+        self.record
+            .get_destinations()
+            .iter()
+            .any(|destination| location.matches(destination))
     }
 
-    fn matches_class(&self, class: &String) -> bool {
-        if let Some(id) = self.record.get_class() {
-            return id.eq_ignore_ascii_case(class);
-        }
-        return false;
+    fn matches_class(&self, class: &str) -> bool {
+        self.record.get_class().eq_ignore_ascii_case(class)
     }
 }
 
@@ -59,9 +56,7 @@ struct Location<'a> {
 impl Location<'_> {
     fn matches(&self, destination: &TravelDestination) -> bool {
         if self.cell.is_interior() {
-            if let Some(id) = &destination.cell {
-                return self.cell.id.eq_ignore_ascii_case(id);
-            }
+            self.cell.name.eq_ignore_ascii_case(&destination.cell)
         } else {
             let [x, y, _] = destination.translation;
             let grid = get_cell_grid(x.into(), y.into());
@@ -70,14 +65,13 @@ impl Location<'_> {
             }
             let dx = (grid.0 - self.cell.data.grid.0).abs();
             let dy = (grid.1 - self.cell.data.grid.1).abs();
-            return dx <= 1 && dy <= 1;
+            dx <= 1 && dy <= 1
         }
-        return false;
     }
 }
 
 impl<'a> Handler<'a> for TravelValidator<'a> {
-    fn on_record(&mut self, _: &Context, record: &'a TES3Object, _: &str, _: &String) {
+    fn on_record(&mut self, _: &Context, record: &'a TES3Object, _: &str, _: &str) {
         if is_dead(record) {
             return;
         }
@@ -88,28 +82,28 @@ impl<'a> Handler<'a> for TravelValidator<'a> {
                 }
             }
             TES3Object::Creature(creature) => {
-                if let Some(destinations) = creature.get_destinations() {
-                    if !destinations.is_empty() {
-                        self.caravaners
-                            .insert(creature.id.to_ascii_lowercase(), Caravaner::new(creature));
-                    }
+                let destinations = creature.get_destinations();
+                if !destinations.is_empty() {
+                    self.caravaners
+                        .insert(creature.id.to_ascii_lowercase(), Caravaner::new(creature));
                 }
             }
             TES3Object::Npc(npc) => {
-                if let Some(destinations) = npc.get_destinations() {
-                    if !destinations.is_empty() {
-                        self.caravaners
-                            .insert(npc.id.to_ascii_lowercase(), Caravaner::new(npc));
-                        return;
-                    }
+                let destinations = npc.get_destinations();
+                if !destinations.is_empty() {
+                    self.caravaners
+                        .insert(npc.id.to_ascii_lowercase(), Caravaner::new(npc));
+                    return;
                 }
-                if let Some(class) = &npc.class {
-                    if self.classes.contains(&class.to_ascii_lowercase().as_str()) {
-                        println!(
-                            "Npc {} has class {} but does not offer travel services",
-                            npc.id, class
-                        );
-                    }
+                // TODO: no alloc (use 'uncased' library?)
+                if self
+                    .classes
+                    .contains(npc.class.to_ascii_lowercase().as_str())
+                {
+                    println!(
+                        "Npc {} has class {} but does not offer travel services",
+                        npc.id, npc.class
+                    );
                 }
             }
             _ => {}
@@ -121,8 +115,8 @@ impl<'a> Handler<'a> for TravelValidator<'a> {
         _: &Context,
         cell: &'a Cell,
         _: &Reference,
-        id: &String,
-        _: &Vec<&Reference>,
+        id: &str,
+        _: &[&Reference],
         _: usize,
     ) {
         if let Some(caravaner) = self.caravaners.get_mut(id) {
@@ -130,18 +124,19 @@ impl<'a> Handler<'a> for TravelValidator<'a> {
         }
     }
 
-    fn on_info(&mut self, _: &Context, record: &'a Info, topic: &Dialogue) {
-        if let Some(id) = &record.speaker_id {
-            if topic.id.eq_ignore_ascii_case("destination") {
-                if let Some(caravaner) = self.caravaners.get_mut(&id.to_ascii_lowercase()) {
-                    caravaner.destination.push(record);
-                }
+    fn on_info(&mut self, _: &Context, record: &'a DialogueInfo, topic: &Dialogue) {
+        if !record.speaker_id.is_empty() && topic.id.eq_ignore_ascii_case("destination") {
+            if let Some(caravaner) = self
+                .caravaners
+                .get_mut(&record.speaker_id.to_ascii_lowercase())
+            {
+                caravaner.destination.push(record);
             }
         }
     }
 
     fn on_end(&mut self, _: &Context) {
-        for (_, caravaner) in &self.caravaners {
+        for caravaner in self.caravaners.values() {
             self.check_caravaner(caravaner);
         }
     }
@@ -149,11 +144,11 @@ impl<'a> Handler<'a> for TravelValidator<'a> {
 
 impl TravelValidator<'_> {
     pub fn new() -> Self {
-        return Self {
+        Self {
             cells: HashMap::new(),
             classes: get_travel_classes(),
             caravaners: HashMap::new(),
-        };
+        }
     }
 
     fn check_caravaner(&self, caravaner: &Caravaner) {
@@ -165,17 +160,17 @@ impl TravelValidator<'_> {
                 typename, id
             );
         }
-        for cell in &caravaner.cells {
+        for location in &caravaner.cells {
             let counterparts: Vec<&Caravaner> = self
                 .caravaners
                 .values()
-                .filter(|c| c.is_counterpart(cell))
+                .filter(|c| c.is_counterpart(location))
                 .collect();
-            for dest in caravaner.record.get_destinations().as_ref().unwrap() {
+            for dest in caravaner.record.get_destinations() {
                 let return_services: Vec<&Caravaner> = counterparts
                     .iter()
                     .filter(|c| c.cells.iter().any(|l| l.matches(dest)))
-                    .map(|c| *c)
+                    .copied()
                     .collect();
                 let (dest_name, town) = self.get_destination_name(dest);
                 if return_services.is_empty() {
@@ -183,12 +178,13 @@ impl TravelValidator<'_> {
                         "{} {} in {} offers travel to {} but there is no return travel there",
                         typename,
                         id,
-                        get_cell_name(cell.cell),
+                        location.cell.editor_id(),
                         dest_name
                     )
-                } else if let Some(class_id) = caravaner.record.get_class() {
+                } else if !caravaner.record.get_class().is_empty() {
+                    let class_id = caravaner.record.get_class();
                     if !return_services.iter().any(|c| c.matches_class(class_id)) {
-                        println!("{} {} in {} offers {} travel to {} but there is no corresponding return travel there", typename, id, get_cell_name(cell.cell), class_id, dest_name);
+                        println!("{} {} in {} offers {} travel to {} but there is no corresponding return travel there", typename, id, location.cell.editor_id(), class_id, dest_name);
                     }
                 }
                 if !town.is_empty()
@@ -197,7 +193,6 @@ impl TravelValidator<'_> {
                         .destination
                         .iter()
                         .map(|i| &i.text)
-                        .flatten()
                         .any(|t| t.contains(town))
                 {
                     println!(
@@ -210,14 +205,14 @@ impl TravelValidator<'_> {
     }
 
     fn get_destination_name<'b>(&'b self, dest: &'b TravelDestination) -> (String, &'b str) {
-        if let Some(cell) = &dest.cell {
-            return (cell.clone(), get_town_name(cell));
+        if !dest.cell.is_empty() {
+            return (dest.cell.clone(), get_town_name(&dest.cell));
         }
         let [x, y, _] = dest.translation;
         let grid = get_cell_grid(x.into(), y.into());
         if let Some(cell) = self.cells.get(&grid) {
-            return (get_cell_name(cell), get_town_name(&cell.id));
+            return (cell.editor_id().into(), get_town_name(&cell.name));
         }
-        return (format!("[{}, {}]", x, y), "");
+        (format!("[{}, {}]", x, y), "")
     }
 }

--- a/src/validators/unicode.rs
+++ b/src/validators/unicode.rs
@@ -1,99 +1,99 @@
 use super::Context;
 use crate::handlers::Handler;
 use regex::Regex;
-use tes3::esp::{Dialogue, Info, TES3Object};
+use tes3::esp::{Dialogue, DialogueInfo, TES3Object, TypeInfo};
 
 pub struct UnicodeValidator {
     invalid: Regex,
 }
 
 impl Handler<'_> for UnicodeValidator {
-    fn on_record(&mut self, _: &Context, record: &TES3Object, typename: &str, id: &String) {
+    fn on_record(&mut self, _: &Context, record: &TES3Object, typename: &str, id: &str) {
         match record {
             TES3Object::Activator(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Alchemy(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Apparatus(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Armor(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Birthsign(r) => {
-                self.test_o(typename, id, "description", &r.description, None);
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "description", &r.description, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Book(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
-                self.test_o(typename, id, "text", &r.text, None);
+                self.test(typename, id, "name", &r.name, None);
+                self.test(typename, id, "text", &r.text, None);
             }
             TES3Object::Class(r) => {
-                self.test_o(typename, id, "description", &r.description, None);
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "description", &r.description, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Clothing(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Container(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Creature(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Door(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Faction(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::GameSetting(_) => {
                 return;
             }
-            TES3Object::Info(_) => {
+            TES3Object::DialogueInfo(_) => {
                 return;
             }
             TES3Object::Ingredient(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Light(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Lockpick(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::MagicEffect(r) => {
-                self.test_o(typename, id, "description", &r.description, None);
+                self.test(typename, id, "description", &r.description, None);
             }
             TES3Object::MiscItem(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Npc(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Probe(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Race(r) => {
-                self.test_o(typename, id, "description", &r.description, None);
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "description", &r.description, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Region(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::RepairItem(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Script(r) => {
-                self.test_o(typename, id, "script_text", &r.script_text, None);
+                self.test(typename, id, "script_text", &r.text, None);
             }
             TES3Object::Spell(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             TES3Object::Weapon(r) => {
-                self.test_o(typename, id, "name", &r.name, None);
+                self.test(typename, id, "name", &r.name, None);
             }
             _ => {}
         }
@@ -102,15 +102,15 @@ impl Handler<'_> for UnicodeValidator {
         }
     }
 
-    fn on_info(&mut self, _: &Context, record: &Info, topic: &Dialogue) {
-        self.test_o(
+    fn on_info(&mut self, _: &Context, record: &DialogueInfo, topic: &Dialogue) {
+        self.test(
             record.type_name(),
             &record.id,
             "text",
             &record.text,
             Some(topic),
         );
-        self.test_o(
+        self.test(
             record.type_name(),
             &record.id,
             "script_text",
@@ -123,30 +123,10 @@ impl Handler<'_> for UnicodeValidator {
 impl UnicodeValidator {
     pub fn new() -> Result<Self, regex::Error> {
         let invalid = Regex::new(r"[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\uffff]")?;
-        return Ok(Self { invalid });
+        Ok(Self { invalid })
     }
 
-    fn test_o(
-        &self,
-        typename: &str,
-        id: &String,
-        field: &str,
-        value: &Option<String>,
-        topic: Option<&Dialogue>,
-    ) {
-        if let Some(s) = value {
-            self.test(typename, id, field, s, topic);
-        }
-    }
-
-    fn test(
-        &self,
-        typename: &str,
-        id: &String,
-        field: &str,
-        value: &String,
-        topic: Option<&Dialogue>,
-    ) {
+    fn test(&self, typename: &str, id: &str, field: &str, value: &str, topic: Option<&Dialogue>) {
         if let Some(m) = self.invalid.find(value) {
             if let Some(dial) = topic {
                 println!(


### PR DESCRIPTION
Switches to the `dev` branch of the `tes3` lib. I plan on merging the branch into `main` eventually, so I want to help user libraries update in preparation.

The main difference is that nearly all subrecord fields that were previously `Option<T>` are now just bare `T`, which means a lot less annoying maps/unwraps/etc. Also relevant for this project is that all the various flags are now properly named (`LightFlags::CAN_CARRY` and so on).

Because the `Option<T>` change touches almost every struct, the diff for updating is quite invasive. I basically just updated `Cargo.toml` and then followed compiler errors until everything was happy. I ran the program on `TR_Mainland.esm` and compared the output logs and it looks correct to me (after sorting the log lines).

I went ahead and ran `cargo fmt` and `cargo clippy` and satisfied all their warnings while I was in there. I also made a few small performance/syntax tweaks. The previous build took 13.6 seconds to process `TR_Mainland.esm` on my PC, it went down to 1.6 seconds after this update.